### PR TITLE
fix: resolves #1 by correcting the typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ivory",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "eslint config for the ivory style guide",
   "keywords": [
     "eslint",

--- a/src/promise.js
+++ b/src/promise.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  plugin: ["promise"],
+  plugins: ["promise"],
   rules: {
     "promise/catch-or-return": ["error", { allowFinally: true }],
     "promise/no-return-wrap": "error",


### PR DESCRIPTION
Corrected the typo from `plugin` to `plugins`.